### PR TITLE
updated certificate location for publisher cert

### DIFF
--- a/provision.ps1
+++ b/provision.ps1
@@ -82,7 +82,7 @@ if ((Get-WmiObject Win32_ComputerSystemProduct Vendor).Vendor -eq 'QEMU') {
     Restart-Service opensshd
 } else {
     Write-Host 'Importing the Oracle (for VirtualBox) certificate as a Trusted Publisher...'
-    E:\cert\VBoxCertUtil.exe add-trusted-publisher E:\cert\vbox-sha1.cer
+    E:\cert\VBoxCertUtil.exe add-trusted-publisher E:\cert\oracle-vbox.cer
     if ($LASTEXITCODE) {
         throw "failed to import certificate with exit code $LASTEXITCODE"
     }


### PR DESCRIPTION
It appears that Oracle changed the location for the certificate causing the ps to fail and killing the box build. This change allows it to complete successfully.