### PR TITLE
Update wget verbosity to be more CI/CD friendly

### DIFF
--- a/provision-drivers.sh
+++ b/provision-drivers.sh
@@ -10,7 +10,7 @@ f="$(basename "$u")"
 if [ ! -f "drivers/$f" ]; then
 	rm -rf drivers drivers.tmp
 	mkdir -p drivers.tmp
-	wget -P drivers.tmp "$u"
+	wget --progress=dot:giga -P drivers.tmp "$u"
 	7z x -odrivers.tmp drivers.tmp/virtio-win-*.iso
 	mv drivers.tmp drivers
 fi


### PR DESCRIPTION
Hello,

Would you be OK to change the progress bar of wget to --progress=dot:giga in provision-drivers.sh?
The current download script generates around 15.000 lines in github actions, with this option you would still have progress showing (in around 30 lines), but you would not generate the 15k lines that pollutes the output.

Before:
<img width="776" height="801" alt="image" src="https://github.com/user-attachments/assets/f49ca8aa-87ff-48ac-beaa-1ae8c4485f6c" />

After:
<img width="776" height="521" alt="image" src="https://github.com/user-attachments/assets/451c8e82-a052-4ab6-9d55-8e27b03ca267" />

Kind regards.